### PR TITLE
shelf scale fix (1)

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,29 +6,37 @@ export const CONFIG: Config = {
     height: 720,
     margin: { top: 90, right: 170, bottom: 90, left: 60 },
   },
+
+  // Camera
   axon: {
     yawDeg: 30,
     pitchDeg: 30,
     rollDeg: 0,
     xScale: 1.0,
-    verticalExaggeration: 10.0,
+    verticalExaggeration: 9,
   },
+
+  // Ribbon depth (10% of distance by default; override with fixed km if needed)
   roof: {
     depthFrac: 0.1,
     depthOverrideKm: null,
-    anchor: "back",
+    anchor: "back", // default: shifted behind ridge
     zOffsetKm: 0,
   },
+
+  // Platform/shelf — fixed pixel height (screen-space)
   platform: {
-    heightM: 100,
+    heightPx: 30,
     fill: "var(--platform)",
     wallFill: "var(--platform-wall)",
   },
+
   grid: { distStepKm: 1, elevLines: 8 },
   road: { strokeWidth: 2.4, dash: "10 10" },
   face: { stroke: "#9aa1aa", strokeWidth: 1.25 },
   titleFontSize: 26,
   labelFontSize: 13,
+
   slopeColors: [
     { upTo: 4.0, color: "#39A7FF" },
     { upTo: 6.0, color: "#1261A0" },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,7 @@ export interface Segment {
   km: number
   grade: number
 }
+
 export interface ClimbData {
   name: string
   segments: Segment[]
@@ -31,7 +32,8 @@ export interface RoofConfig {
 }
 
 export interface PlatformConfig {
-  heightM: number
+  /** Fixed pixel height for the shelf (screen-space). */
+  heightPx: number
   fill: string
   wallFill: string
 }


### PR DESCRIPTION
Config/type change: platform.heightM → platform.heightPx (fixed pixel shelf).

Fit: we fit the world only into canvas.height - heightPx to avoid clipping once the shelf is added.

Shelf vector: compute shelfVec as the projected direction of +Y world, normalized, scaled to heightPx.

Perfect centering: apply a global shift of −½·shelfVec to all projected points (P wrapper). Then draw the face/roof/grid lifted by +shelfVec. The axis (Y=0) remains unlifted—so the combined bounding (axis below, shelf+face above) is centered.

Drawing: shelf, face, grid, roof, and elevation axis use addShelf(P(...)); distance axis uses P(..., 0).