### PR TITLE
Add optional starting elevation to profile chart

### DIFF
--- a/src/components/ProfileChart.tsx
+++ b/src/components/ProfileChart.tsx
@@ -103,6 +103,7 @@ export default function ProfileChart({
       totalKm,
       totalGainM,
       elevSpanM,
+      elevMin,
       P,
       shelfVec,
     }
@@ -120,6 +121,7 @@ export default function ProfileChart({
     totalKm,
     totalGainM,
     elevSpanM,
+    elevMin,
     P,
     shelfVec,
   } = model
@@ -147,6 +149,8 @@ export default function ProfileChart({
   const distStep = config.grid.distStepKm || 1
   const stepM = niceStep(elevSpanM, config.grid.elevLines)
   const stepYkm = stepM / 1000
+
+  const axisMinM = (data.startElevationM ?? 0) + elevMin
 
   // Roof near/far profiles (also lifted by shelfVec)
   const nearPts2D = worldPts.map((pt) => addShelf(P(pt.X, pt.Y, zNear)))
@@ -338,7 +342,7 @@ export default function ProfileChart({
               <g key={`ey-${m}`}>
                 <line x1={p.x} y1={p.y} x2={p.x + yN.x * 6} y2={p.y + yN.y * 6} stroke="#111827" />
                 <text x={p.x + yN.x * 14} y={p.y + yN.y * 14}>
-                  {m | 0} m
+                  {Math.round(axisMinM + m)} m
                 </text>
               </g>
             )

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -2,6 +2,7 @@ import { ClimbData } from "./types"
 
 export const SAMPLE: ClimbData = {
   name: "Grand Colombier",
+  startElevationM: 0,
   segments: [
     { km: 1.0, grade: 5.8 },
     { km: 1.0, grade: 7.4 },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,8 @@ export interface Segment {
 export interface ClimbData {
   name: string
   segments: Segment[]
+  /** Starting elevation in meters above sea level */
+  startElevationM?: number
 }
 
 export interface CanvasConfig {


### PR DESCRIPTION
## Summary
- allow `ClimbData` to include a `startElevationM` value
- use the start elevation when computing y-axis labels in `ProfileChart`
- document `startElevationM` in sample data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c4ba286cb88324b0a6a287b6334d90